### PR TITLE
Connect frontend to Apps Script API

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,52 +23,48 @@
     <h1>Registro de Actividad</h1>
 
     <form id="registroForm">
-      <label>Fecha
-        <input type="date" name="fecha" required>
+      <label for="fecha">Fecha
+        <input id="fecha" type="date" name="fecha" required>
       </label>
 
       <div class="cols">
-        <label>Hora Entrada
-          <input type="time" name="horarioEntrada" required>
+        <label for="horarioEntrada">Hora Entrada
+          <input id="horarioEntrada" type="time" name="horarioEntrada" required>
         </label>
-        <label>Hora Salida
-          <input type="time" name="horarioSalida">
+        <label for="horarioSalida">Hora Salida
+          <input id="horarioSalida" type="time" name="horarioSalida">
         </label>
       </div>
 
-      <label>N° de rollo
-        <input name="nroRollo" type="number">
+      <label for="nroRollo">N° de rollo
+        <input id="nroRollo" name="nroRollo" type="text">
       </label>
 
-      <label>Pasadas /10 cm
-        <input name="pasadasReales" type="number">
+      <label for="pasadasReales">Pasadas /10 cm
+        <input id="pasadasReales" name="pasadasReales" type="number" step="1" inputmode="numeric">
       </label>
 
-      <div class="cols">
-        <label>Cant. personas
-          <input name="cantidadPersonas" type="number" min="1" value="1">
+      <div class="cols cols--stretch">
+        <label for="cantPersonas">Cant. personas
+          <select id="cantPersonas" name="cantPersonas"></select>
         </label>
-        <label>Operario
-          <input name="operario1" list="opers">
-        </label>
-        <datalist id="opers">
-          <option>Sturtz</option>
-          <option>Marcos</option>
-          <option>Anita</option>
-        </datalist>
+        <div class="multi-operarios">
+          <span class="multi-operarios__label">Operario(s)</span>
+          <div id="operariosContainer"></div>
+        </div>
       </div>
 
       <div class="cols">
-        <label>Mts iniciales
-          <input name="mtsIniciales" type="number" step="0.01">
+        <label for="mtsIniciales">Mts iniciales
+          <input id="mtsIniciales" name="mtsIniciales" type="number" step="0.01" required inputmode="decimal">
         </label>
-        <label>Mts finales
-          <input name="mtsFinales" type="number" step="0.01">
+        <label for="mtsFinales">Mts finales
+          <input id="mtsFinales" name="mtsFinales" type="number" step="0.01" required inputmode="decimal">
         </label>
       </div>
 
-      <label>Observaciones
-        <textarea name="observaciones" rows="3"></textarea>
+      <label for="observaciones">Observaciones
+        <textarea id="observaciones" name="observaciones" rows="3"></textarea>
       </label>
 
       <button class="btn-ok" type="submit">Guardar Registro</button>

--- a/script.js
+++ b/script.js
@@ -1,87 +1,235 @@
-/* ---- Pantalla 1: cargar detalles ---- */
-const tabla     = document.getElementById('detalleTabla');
-const btnCont   = document.getElementById('btnContinuar');
-const intro     = document.getElementById('intro');
-const formWrap  = document.getElementById('formWrap');
-const form      = document.getElementById('registroForm');
-const msg       = document.getElementById('msg');
+const API_URL = 'https://script.google.com/macros/s/AKfycbyMGJOJ8z3GcqtgrpmtA7CiKuCNRwgK0RK97_6I0MTcM5oxwGqg13TAP7RIjAd7Q4Ey/exec';
+
+/* ---- Referencias UI ---- */
+const tabla = document.getElementById('detalleTabla');
+const btnCont = document.getElementById('btnContinuar');
+const intro = document.getElementById('intro');
+const formWrap = document.getElementById('formWrap');
+const form = document.getElementById('registroForm');
+const msg = document.getElementById('msg');
+const cantPersonasSelect = document.getElementById('cantPersonas');
+const operariosContainer = document.getElementById('operariosContainer');
+const fechaInput = document.getElementById('fecha');
 
 let fixedData = {};
+let operariosDisponibles = [];
 
 const NORMALIZE_LABEL = /(^.|_.)/g;
 
-function updateFixedData(data) {
+/* ---- Helpers ---- */
+const formatLabel = (key) => key
+  .replace(NORMALIZE_LABEL, (fragment) => fragment.replace('_', ' ').toUpperCase());
+
+const showTableMessage = (message) => {
+  tabla.innerHTML = `<tr><td colspan="2">${message}</td></tr>`;
+};
+
+const setTodayAsDefaultDate = () => {
+  if (!fechaInput) return;
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const dd = String(today.getDate()).padStart(2, '0');
+  fechaInput.value = `${yyyy}-${mm}-${dd}`;
+};
+
+const createSelectOption = (value, text = value) => {
+  const option = document.createElement('option');
+  option.value = String(value);
+  option.textContent = text;
+  return option;
+};
+
+const renderOperarioFields = () => {
+  const cantidad = parseInt(cantPersonasSelect.value, 10) || 1;
+  operariosContainer.innerHTML = '';
+
+  for (let i = 1; i <= cantidad; i += 1) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'operario-field';
+
+    const caption = document.createElement('span');
+    caption.className = 'operario-field__caption';
+    caption.textContent = cantidad === 1 ? 'Operario' : `Operario ${i}`;
+    wrapper.appendChild(caption);
+
+    const select = document.createElement('select');
+    select.name = `operario${i}`;
+    select.required = true;
+
+    if (operariosDisponibles.length === 0) {
+      select.appendChild(createSelectOption('', 'Sin operarios'));
+    } else {
+      operariosDisponibles.forEach((operario) => {
+        select.appendChild(createSelectOption(operario));
+      });
+    }
+
+    wrapper.appendChild(select);
+    operariosContainer.appendChild(wrapper);
+  }
+};
+
+const handleDropdownData = (data) => {
+  const personas = Array.isArray(data?.personas) && data.personas.length > 0
+    ? data.personas
+    : ['1', '2', '3', '4'];
+
+  cantPersonasSelect.innerHTML = '';
+  personas.forEach((persona) => {
+    cantPersonasSelect.appendChild(createSelectOption(persona));
+  });
+
+  if (cantPersonasSelect.options.length > 0) {
+    cantPersonasSelect.value = cantPersonasSelect.options[0].value;
+  }
+
+  operariosDisponibles = Array.isArray(data?.operarios) && data.operarios.length > 0
+    ? data.operarios
+    : [];
+
+  renderOperarioFields();
+};
+
+const updateFixedData = (data) => {
   fixedData = data || {};
   tabla.innerHTML = '';
 
   if (!data || Object.keys(data).length === 0) {
-    tabla.innerHTML = '<tr><td colspan="2">No se encontraron detalles para mostrar.</td></tr>';
+    showTableMessage('No se encontraron detalles para mostrar.');
     return;
   }
 
-  for (const [key, value] of Object.entries(data)) {
-    const label = key.replace(NORMALIZE_LABEL, s => s.replace('_', ' ').toUpperCase());
-    const row = `<tr><td>${label}</td><td>${value ?? ''}</td></tr>`;
-    tabla.insertAdjacentHTML('beforeend', row);
-  }
-}
+  Object.entries(data).forEach(([key, value]) => {
+    const row = document.createElement('tr');
 
-function showError(err) {
-  console.error(err);
-  tabla.innerHTML = '<tr><td colspan="2">No se pudieron cargar los detalles del pedido.</td></tr>';
-}
+    const labelCell = document.createElement('td');
+    labelCell.textContent = formatLabel(key);
 
-tabla.innerHTML = '<tr><td colspan="2">Cargando detalles...</td></tr>';
+    const valueCell = document.createElement('td');
+    valueCell.textContent = value ?? '';
 
-google.script.run
-  .withSuccessHandler(updateFixedData)
-  .withFailureHandler(showError)
-  .getFXLOptionsData();
-
-btnCont.onclick = () => {
-  intro.classList.add('hidden');
-  formWrap.classList.remove('hidden');
-  window.scrollTo(0,0);
+    row.appendChild(labelCell);
+    row.appendChild(valueCell);
+    tabla.appendChild(row);
+  });
 };
 
-/* ---- Pantalla 2: enviar registro ---- */
-form.addEventListener('submit', e => {
-  e.preventDefault();
-  msg.textContent = 'Enviando...';
+const showError = (error) => {
+  console.error('Error al cargar datos:', error);
+  showTableMessage('No se pudieron cargar los detalles del pedido.');
+};
 
+const fetchJson = async (url, options) => {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`Solicitud fallida (${response.status})`);
+  }
+  return response.json();
+};
+
+const loadFixedData = async () => {
+  try {
+    showTableMessage('Cargando detalles...');
+    const data = await fetchJson(`${API_URL}?action=getOptions`);
+    if (data?.error) {
+      throw new Error(data.error);
+    }
+    updateFixedData(data);
+  } catch (error) {
+    showError(error);
+  }
+};
+
+const loadDropdowns = async () => {
+  try {
+    const data = await fetchJson(`${API_URL}?action=getDropdowns`);
+    if (data?.error) {
+      throw new Error(data.error);
+    }
+    handleDropdownData(data);
+  } catch (error) {
+    console.error('Error al cargar desplegables:', error);
+    handleDropdownData({});
+  }
+};
+
+const buildPayload = () => {
   const formEntries = Array.from(new FormData(form).entries())
     .map(([key, value]) => [key, typeof value === 'string' ? value.trim() : value]);
+
   const datos = Object.fromEntries(formEntries);
-  const operariosLista = formEntries
+
+  const operarios = formEntries
     .filter(([key]) => key.toLowerCase().startsWith('operario'))
     .map(([, value]) => value)
-    .filter(value => value !== undefined && value !== null && value !== '');
+    .filter((value) => value);
 
-  const payload = { ...datos, operariosLista };
+  const payload = {
+    ...datos,
+    operariosLista: operarios.join(', '),
+  };
 
-  for (const [key, value] of Object.entries(fixedData)) {
-    payload[key] = value ?? '';
+  Object.entries(fixedData).forEach(([key, value]) => {
+    payload[`${key}_fijo`] = value ?? '';
+  });
+
+  return payload;
+};
+
+const sendPayload = async (payload) => {
+  const response = await fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`No se pudo guardar (HTTP ${response.status})`);
   }
 
-  google.script.run
-    .withSuccessHandler(onSaveSuccess)
-    .withFailureHandler(onSaveError)
-    .saveEntry(payload);
-});
+  return response.json();
+};
 
-function onSaveSuccess(response) {
-  if (!response || response.ok) {
+const onSaveSuccess = (result) => {
+  if (result?.status === 'OK') {
     msg.textContent = '✅ ¡Registro guardado!';
     form.reset();
+    setTodayAsDefaultDate();
+    renderOperarioFields();
   } else {
-    const err = response && response.error ? response.error : 'Error desconocido';
-    onSaveError(err);
+    const message = result?.message || 'Error desconocido al guardar.';
+    onSaveError(new Error(message));
   }
-}
+};
 
-function onSaveError(error) {
-  const message = typeof error === 'string'
-    ? error
-    : (error && error.message) ? error.message : 'Error desconocido';
-  msg.textContent = '❌ Error: ' + message;
-}
+const onSaveError = (error) => {
+  const message = error?.message || 'Error desconocido al guardar.';
+  msg.textContent = `❌ Error: ${message}`;
+};
+
+/* ---- Inicialización ---- */
+setTodayAsDefaultDate();
+loadFixedData();
+loadDropdowns();
+
+btnCont.addEventListener('click', () => {
+  intro.classList.add('hidden');
+  formWrap.classList.remove('hidden');
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+});
+
+cantPersonasSelect.addEventListener('change', renderOperarioFields);
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  msg.textContent = 'Enviando...';
+
+  try {
+    const payload = buildPayload();
+    const result = await sendPayload(payload);
+    onSaveSuccess(result);
+  } catch (error) {
+    onSaveError(error);
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,41 @@ textarea { resize: vertical; }
 .cols { display: flex; gap: .5rem; }
 .cols > label { flex: 1; }
 
+.cols--stretch { align-items: flex-start; }
+.cols--stretch > label,
+.cols--stretch > .multi-operarios { flex: 1; }
+
+.multi-operarios {
+  display: flex;
+  flex-direction: column;
+  gap: .4rem;
+}
+
+.multi-operarios__label {
+  font-size: .9rem;
+  opacity: .85;
+}
+
+#operariosContainer {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+
+.operario-field {
+  display: flex;
+  flex-direction: column;
+  gap: .3rem;
+}
+
+.operario-field__caption {
+  font-size: .9rem;
+}
+
+.operario-field select {
+  width: 100%;
+}
+
 .btn-ok {
   width: 100%;
   padding: .8rem 0;


### PR DESCRIPTION
## Summary
- replace in-apps-script calls with fetch requests against the deployed Apps Script web app
- send fixed sheet metadata and normalized operario payloads expected by saveEntry
- refresh the form layout to support dynamic person counts and operario selectors

## Testing
- Not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c9853c3bf48320ad13fea0776d77cb