### PR TITLE
Bloquea continuar hasta cargar datos fijos

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,7 @@ const handleDropdownData = (data) => {
 };
 
 const updateFixedData = (data) => {
+  btnCont.disabled = true;
   fixedData = data || {};
   tabla.innerHTML = '';
 
@@ -99,6 +100,8 @@ const updateFixedData = (data) => {
     showTableMessage('No se encontraron detalles para mostrar.');
     return;
   }
+
+  btnCont.disabled = false;
 
   Object.entries(data).forEach(([key, value]) => {
     const row = document.createElement('tr');
@@ -155,6 +158,10 @@ const loadDropdowns = async () => {
 };
 
 const buildPayload = () => {
+  if (!fixedData || Object.keys(fixedData).length === 0) {
+    throw new Error('Datos fijos no disponibles. Por favor recarga la página e inténtalo nuevamente.');
+  }
+
   const formEntries = Array.from(new FormData(form).entries())
     .map(([key, value]) => [key, typeof value === 'string' ? value.trim() : value]);
 
@@ -210,6 +217,7 @@ const onSaveError = (error) => {
 
 /* ---- Inicialización ---- */
 setTodayAsDefaultDate();
+btnCont.disabled = true;
 loadFixedData();
 loadDropdowns();
 


### PR DESCRIPTION
## Summary
- deshabilitar el botón Continuar hasta que se carguen los datos fijos válidos
- impedir el envío del formulario si los datos fijos no están disponibles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cace5e0ed483208fffa7e05cba2fd7